### PR TITLE
Update rentalOfferHistory to push offers manually

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -38,7 +38,7 @@ type Nft @entity(immutable: false) {
   rentalHistory: [Rental!]! @derivedFrom(field: "nft")
 
   currentRentalOffer: RentalOffer
-  rentalOfferHistory: [RentalOffer!]! @derivedFrom(field: "nfts")
+  rentalOfferHistory: [RentalOffer!]
 }
 
 type Account @entity(immutable: false) {

--- a/src/aavegotchi/gotchi/gotchi-lending-added-handler.ts
+++ b/src/aavegotchi/gotchi/gotchi-lending-added-handler.ts
@@ -55,6 +55,13 @@ export function handleGotchiLendingAdded(event: GotchiLendingAdded): void {
 
   // link rental offer to nft
   nft.currentRentalOffer = rentalOfferId;
+
+  if (!nft.rentalOfferHistory) {
+    nft.rentalOfferHistory = [rentalOfferId];
+  } else {
+    nft.rentalOfferHistory = nft.rentalOfferHistory!.concat([rentalOfferId]);
+  }
+
   nft.save();
 
   log.warning("[GotchiLendingAdded]: Gotchi {} added to rental offer {}", [

--- a/src/aavegotchi/gotchi/gotchi-lending-added-handler.ts
+++ b/src/aavegotchi/gotchi/gotchi-lending-added-handler.ts
@@ -1,7 +1,7 @@
 import { BigInt, log } from "@graphprotocol/graph-ts";
 import { GotchiLendingAdded } from "../../../generated/AavegotchiDiamond/AavegotchiDiamond";
 import { Nft, RentalOffer } from "../../../generated/schema";
-import { generateNftId } from "../../utils/misc";
+import { generateNftId, updateNftRentalOfferHistory } from "../../utils/misc";
 import { GHST_TOKEN_ADDRESS } from "../../utils/addresses";
 import { MAX_UINT256, ONE_ETHER } from "../../utils/constants";
 
@@ -55,14 +55,9 @@ export function handleGotchiLendingAdded(event: GotchiLendingAdded): void {
 
   // link rental offer to nft
   nft.currentRentalOffer = rentalOfferId;
-
-  if (!nft.rentalOfferHistory) {
-    nft.rentalOfferHistory = [rentalOfferId];
-  } else {
-    nft.rentalOfferHistory = nft.rentalOfferHistory!.concat([rentalOfferId]);
-  }
-
   nft.save();
+
+  updateNftRentalOfferHistory(rentalOffer, nft);
 
   log.warning("[GotchiLendingAdded]: Gotchi {} added to rental offer {}", [
     nftId,

--- a/src/cometh/rental-protocol/rental-offer-created-handler.ts
+++ b/src/cometh/rental-protocol/rental-offer-created-handler.ts
@@ -2,7 +2,7 @@ import { BigInt } from '@graphprotocol/graph-ts'
 import { RentalOffer } from '../../../generated/schema'
 import { COMETHSPACESHIP } from '../../utils/constants'
 import { RentalOfferCreated } from '../../../generated/ComethRentalProtocol/ComethRentalProtocol'
-import { loadNfts } from '../../utils/misc'
+import { loadNfts, updateNftRentalOfferHistory } from '../../utils/misc'
 import { log } from '@graphprotocol/graph-ts'
 import { SPACESHIP_ADDRESS } from '../../utils/addresses'
 /**
@@ -52,15 +52,7 @@ export function handleRentalOfferCreated(event: RentalOfferCreated): void {
   rentalOffer.save()
 
   for (let i = 0; i < foundNfts.length; i++) {
-    const foundNft = foundNfts[i]
-
-    if (!foundNft.rentalOfferHistory) {
-      foundNft.rentalOfferHistory = [rentalOfferId];
-    } else {
-      foundNft.rentalOfferHistory = foundNft.rentalOfferHistory!.concat([rentalOfferId]);
-    }
-
-    foundNft.save()
+    updateNftRentalOfferHistory(rentalOffer, foundNfts[i]);
   }
 
   log.warning('[handleRentalOfferCreated] RentalOffer {} created for NFTs {}, tx: {}', [

--- a/src/cometh/rental-protocol/rental-offer-created-handler.ts
+++ b/src/cometh/rental-protocol/rental-offer-created-handler.ts
@@ -51,6 +51,18 @@ export function handleRentalOfferCreated(event: RentalOfferCreated): void {
   rentalOffer.expirationDate = event.params.deadline
   rentalOffer.save()
 
+  for (let i = 0; i < foundNfts.length; i++) {
+    const foundNft = foundNfts[i]
+
+    if (!foundNft.rentalOfferHistory) {
+      foundNft.rentalOfferHistory = [rentalOfferId];
+    } else {
+      foundNft.rentalOfferHistory = foundNft.rentalOfferHistory!.concat([rentalOfferId]);
+    }
+
+    foundNft.save()
+  }
+
   log.warning('[handleRentalOfferCreated] RentalOffer {} created for NFTs {}, tx: {}', [
     rentalOfferId,
     rentalOffer.nfts.toString(),

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -50,3 +50,11 @@ export function loadRentalOffer(rentalOfferId: string): RentalOffer {
 
   return rentalOffer;
 }
+
+export function updateNftRentalOfferHistory(
+  rentalOffer: RentalOffer,
+  nft: Nft
+): void {
+  nft.rentalOfferHistory = nft.rentalOfferHistory ? nft.rentalOfferHistory!.concat([rentalOffer.id]) : [rentalOffer.id];
+  nft.save();
+}

--- a/tests/matic/aavegotchi/gotchi-lending-added-handler.test.ts
+++ b/tests/matic/aavegotchi/gotchi-lending-added-handler.test.ts
@@ -53,6 +53,7 @@ describe("Aavegotchi Rentals", () => {
     const rentalOfferId = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
     const nftId = "AAVEGOTCHI-" + tokenId;
     assert.fieldEquals("Nft", nftId, "currentRentalOffer", rentalOfferId);
+    assert.fieldEquals("Nft", nftId, "rentalOfferHistory", `[${rentalOfferId}]`);
     assert.fieldEquals("RentalOffer", rentalOfferId, "nfts", `[${nftId}]`);
     assert.fieldEquals("RentalOffer", rentalOfferId, "lender", lender);
     assert.fieldEquals(
@@ -114,6 +115,7 @@ describe("Aavegotchi Rentals", () => {
     const nftId = "AAVEGOTCHI-" + tokenId;
 
     assert.fieldEquals("Nft", nftId, "currentRentalOffer", rentalOfferId);
+    assert.fieldEquals("Nft", nftId, "rentalOfferHistory", `[${rentalOfferId}]`);
     assert.fieldEquals("RentalOffer", rentalOfferId, "nfts", `[${nftId}]`);
     assert.fieldEquals("RentalOffer", rentalOfferId, "lender", lender);
     assert.fieldEquals(

--- a/tests/matic/cometh/rental-offer-created-handler.test.ts
+++ b/tests/matic/cometh/rental-offer-created-handler.test.ts
@@ -39,6 +39,7 @@ describe('Cometh - Rental Offer Created Event', () => {
     const rentalOfferId = `${maker}-${nonce}`
     const nftId = `${COMETHSPACESHIP}-${tokenId}`
 
+    assert.fieldEquals('Nft', nftId, 'rentalOfferHistory', `[${rentalOfferId}]`)
     assert.fieldEquals('RentalOffer', rentalOfferId, 'nfts', `[${nftId}]`)
     assert.fieldEquals('RentalOffer', rentalOfferId, 'lender', maker)
     assert.fieldEquals('RentalOffer', rentalOfferId, 'createdAt', event.block.timestamp.toString())


### PR DESCRIPTION
- Remove `derivedFrom` from `rentalOfferHistory` to enable the use of `rentalOfferHistory: null` and `rentalOfferHistory_: { ... }`at the same query. (the old schema just allowed the last one) 
- Pushes the offers manually to the array for Cometh and Aavegotchi handlers (the only games with rental offer support yet)
- [QA satsuma subgraph](https://app.satsuma.xyz/subgraphs/269/versions/1252)